### PR TITLE
 Added support for RSR IPC control

### DIFF
--- a/Battlevest/Battlevest.cs
+++ b/Battlevest/Battlevest.cs
@@ -13,7 +13,7 @@ public class Battlevest : IDalamudPlugin
     public Battlevest(IDalamudPluginInterface pi)
     {
         P = this;
-        ECommonsMain.Init(pi, this);
+        ECommonsMain.Init(pi, this, Module.DalamudReflector);
         C = EzConfig.Init<Config>();
         SingletonServiceManager.Initialize(typeof(S));
     }

--- a/Battlevest/Data/Config.cs
+++ b/Battlevest/Data/Config.cs
@@ -18,4 +18,5 @@ public class Config : IEzConfig
     public bool EnableKeySpam = true;
     public (int Hotbar, int Slot) HotbarSlot = (0, 0);
     public bool UseKeyMode = true;
+    public bool UseRSR = false;
 }

--- a/Battlevest/Gui/MainWindow.cs
+++ b/Battlevest/Gui/MainWindow.cs
@@ -54,13 +54,16 @@ public unsafe class MainWindow : ConfigWindow
             ImGuiEx.PluginAvailabilityIndicator([new("TextAdvance", new Version(3, 2, 3, 7))]);
             ImGuiEx.TextWrapped("- Vnavmesh installed and enabled");
             ImGuiEx.PluginAvailabilityIndicator([new("vnavmesh")]);
-            ImGuiEx.TextWrapped("- Wrath Combo or any other combo that can put significant part of your rotation to one button. If you are overlevelled, you can skip combo and just spam single GCD. Note that autorotation plugins will likely not work with Battlevest, so do not enable them. ");
+            ImGuiEx.TextWrapped("- Wrath Combo or any other combo that can put significant part of your rotation to one button. If you are overlevelled, you can skip combo and just spam single GCD. Note that unspecified autorotation plugins will likely not work with Battlevest, so do not enable them. ");
             ImGuiEx.TextWrapped("Additionally:");
             ImGuiEx.TextWrapped("- Best results are achieved on ranged jobs");
             ImGuiEx.TextWrapped("- BossMod's AI can be used to avoid AOE");
         })
         .Section("Settings").Widget(() =>
         {
+            ImGui.Checkbox("Use RotationSolverReborn for attacking mobs", ref C.UseRSR);
+            ImGui.SameLine();
+            ImGuiEx.PluginAvailabilityIndicator([new("RotationSolver")]);
             ImGui.Checkbox("Use single key press to attack mobs", ref C.EnableKeySpam);
             ImGui.Indent();
             ImGuiEx.Text("Select mode:");

--- a/Battlevest/Services/Core.cs
+++ b/Battlevest/Services/Core.cs
@@ -106,11 +106,19 @@ public unsafe class Core : IDisposable
                 }
                 else
                 {
+                    if (C.UseRSR && RSR_IPCSubscriber.IsEnabled)
+                    {
+                        RSR_IPCSubscriber.RotationAuto();
+                    }
                     Utils.HandleCombat(npc() != null && Player.DistanceTo(npc()) < 10f, Selected);
                 }
             }
             else
             {
+                if (C.UseRSR && RSR_IPCSubscriber.IsEnabled)
+                {
+                    RSR_IPCSubscriber.RotationStop();
+                }
                 S.TextAdvanceIPC.Stop();
                 var currentLeves = QuestManager.Instance()->LeveQuests.ToArray().Where(x => x.Flags == 0 && Selected.LeveList.Contains(x.LeveId)).OrderBy(x => Utils.GetDistanceToLeve(x.LeveId));
                 if(currentLeves.Any())

--- a/Battlevest/Services/RotationSolverRebornIPC.cs
+++ b/Battlevest/Services/RotationSolverRebornIPC.cs
@@ -1,0 +1,266 @@
+﻿using ECommons.EzIpcManager;
+using ECommons.Reflection;
+using System.ComponentModel;
+
+namespace Battlevest.Services
+{
+    internal class RotationSolverRebornIPC
+    {
+        internal static bool IsReady(string pluginName)
+        {
+            try
+            {
+                return DalamudReflector.TryGetDalamudPlugin(pluginName, out var dalamudPlugin, false, true);
+            }
+            catch (Exception ex)
+            {
+                // Avoid throwing from framework update tick; treat as not ready when reflection isn't initialized
+                Svc.Log.Verbose($"RotationSolverRebornIPC.IsReady: reflection check failed: {ex.Message}");
+                return false;
+            }
+        }
+
+        internal static Version Version(string pluginName)
+        {
+            try
+            {
+                return DalamudReflector.TryGetDalamudPlugin(pluginName, out var dalamudPlugin, false, true)
+                    ? dalamudPlugin.GetType().Assembly.GetName().Version
+                    : new Version(0, 0, 0, 0);
+            }
+            catch (Exception ex)
+            {
+                Svc.Log.Verbose($"RotationSolverRebornIPC.Version: reflection check failed: {ex.Message}");
+                return new Version(0, 0, 0, 0);
+            }
+        }
+
+        internal static void DisposeAll(EzIPCDisposalToken[] _disposalTokens)
+        {
+            foreach (var token in _disposalTokens)
+            {
+                try
+                {
+                    token.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    Svc.Log.Error($"Error while unregistering IPC: {ex}");
+                }
+            }
+        }
+    }
+
+    public static class RSR_IPCSubscriber
+    {
+        /// <summary>
+        /// The state of the plugin.
+        /// </summary>
+        public enum StateCommandType : byte
+        {
+            /// <summary>
+            /// Stop the addon. Always remember to turn it off when it is not in use!
+            /// </summary>
+            [Description("Stop the addon. Always remember to turn it off when it is not in use!")]
+            Off,
+
+            /// <summary>
+            /// Start the addon in Auto mode. When out of combat or when combat starts, switches the target according to the set condition.
+            /// </summary>
+            [Description("Start the addon in Auto mode. When out of combat or when combat starts, switches the target according to the set condition. " +
+                         "\r\n Optionally: You can add the target type to the end of the command you want RSR to do. For example: /rotation Auto Big")]
+            Auto,
+
+            /// <summary>
+            /// Start the addon in Target-Only mode. RSR will auto-select targets per normal logic but will not perform any actions.
+            /// </summary>
+            [Description("Start in Target-Only mode. RSR will auto-select targets per normal logic but will not perform any actions.")]
+            TargetOnly,
+
+            /// <summary>
+            /// Start the addon in Manual mode. You need to choose the target manually. This will bypass any engage settings that you have set up and will start attacking immediately once something is targeted.
+            /// </summary>
+            [Description("Start the addon in Manual mode. You need to choose the target manually. This will bypass any engage settings that you have set up and will start attacking immediately once something is targeted.")]
+            Manual,
+
+            /// <summary>
+            /// 
+            /// </summary>
+            [Description("This mode is managed by the AutoDuty plugin")]
+            AutoDuty,
+
+            /// <summary>
+            /// 
+            /// </summary>
+            [Description("This mode is managed by the Henchman plugin, or any other plugin that requires RSR just do rotation and not targetting.")]
+            Henched,
+        }
+
+        /// <summary>
+        /// Some Other Commands.
+        /// </summary>
+        public enum OtherCommandType : byte
+        {
+            /// <summary>
+            /// Open the settings.
+            /// </summary>
+            [Description("Open the settings.")]
+            Settings,
+
+            /// <summary>
+            /// Open the rotations.
+            /// </summary>
+            [Description("Open the rotations.")]
+            Rotations,
+
+            /// <summary>
+            /// Open the rotations.
+            /// </summary>
+            [Description("Open the duty rotations.")]
+            DutyRotations,
+
+            /// <summary>
+            /// Perform the actions.
+            /// </summary>
+            [Description("Perform the actions.")]
+            DoActions,
+
+            /// <summary>
+            /// Toggle the actions.
+            /// </summary>
+            [Description("Toggle the actions.")]
+            ToggleActions,
+
+            /// <summary>
+            /// Do the next action.
+            /// </summary>
+            [Description("Do the next action.")]
+            NextAction,
+        }
+
+        /// <summary>
+        /// Hostile target.
+        /// </summary>
+        public enum TargetHostileType : byte
+        {
+            /// <summary>
+            /// All targets that are in range for any abilities (Tanks/Autoduty).
+            /// </summary>
+            [Description("All targets that are in range for any abilities (Tanks/Autoduty)")]
+            AllTargetsCanAttack,
+
+            /// <summary>
+            /// Previously engaged targets (Non-Tanks).
+            /// </summary>
+            [Description("Previously engaged targets (Non-Tanks)")]
+            TargetsHaveTarget,
+
+            /// <summary>
+            /// All targets when solo in duty, or previously engaged.
+            /// </summary>
+            [Description("All targets when solo in duty (includes Occult Crescent), or previously engaged.")]
+            AllTargetsWhenSoloInDuty,
+
+            /// <summary>
+            /// All targets when solo, or previously engaged.
+            /// </summary>
+            [Description("All targets when solo, or previously engaged.")]
+            AllTargetsWhenSolo
+        }
+
+        public static string GetHostileTypeDescription(TargetHostileType type)
+        {
+            return type switch
+            {
+                TargetHostileType.AllTargetsCanAttack => "All Targets Can Attack aka Tank/Autoduty Mode",
+                TargetHostileType.TargetsHaveTarget => "Targets Have A Target",
+                TargetHostileType.AllTargetsWhenSoloInDuty => "All Targets When Solo In Duty",
+                TargetHostileType.AllTargetsWhenSolo => "All Targets When Solo",
+                _ => "Unknown Target Type"
+            };
+        }
+
+        /// <summary>
+        /// The type of targeting.
+        /// </summary>
+        public enum TargetingType
+        {
+            /// <summary>
+            /// Find the target whose hit box is biggest.
+            /// </summary>
+            [Description("Big")]
+            Big,
+
+            /// <summary>
+            /// Find the target whose hit box is smallest.
+            /// </summary>
+            [Description("Small")]
+            Small,
+
+            /// <summary>
+            /// Find the target whose HP is highest.
+            /// </summary>
+            [Description("High HP")]
+            HighHP,
+
+            /// <summary>
+            /// Find the target whose HP is lowest.
+            /// </summary>
+            [Description("Low HP")]
+            LowHP,
+
+            /// <summary>
+            /// Find the target whose HP percentage is highest.
+            /// </summary>
+            [Description("High HP%")]
+            HighHPPercent,
+
+            /// <summary>
+            /// Find the target whose HP percentage is lowest.
+            /// </summary>
+            [Description("Low HP%")]
+            LowHPPercent,
+
+            /// <summary>
+            /// Find the target whose max HP is highest.
+            /// </summary>
+            [Description("High Max HP")]
+            HighMaxHP,
+
+            /// <summary>
+            /// Find the target whose max HP is lowest.
+            /// </summary>
+            [Description("Low Max HP")]
+            LowMaxHP,
+
+            /// <summary>
+            /// Find the target that is nearest.
+            /// </summary>
+            [Description("Nearest")]
+            Nearest,
+
+            /// <summary>
+            /// Find the target that is farthest.
+            /// </summary>
+            [Description("Farthest")]
+            Farthest,
+        }
+
+        private static EzIPCDisposalToken[] _disposalTokens = EzIPC.Init(typeof(RSR_IPCSubscriber), "RotationSolverReborn", SafeWrapper.IPCException);
+        public static bool IsEnabled => RotationSolverRebornIPC.IsReady("RotationSolver");
+
+        [EzIPC] private static readonly Action<StateCommandType, TargetingType> AutodutyChangeOperatingMode;
+        [EzIPC] private static readonly Action<StateCommandType> ChangeOperatingMode;
+        [EzIPC] private static readonly Action<OtherCommandType, string> OtherCommand;
+
+        public static void RotationAuto()
+        {
+            ChangeOperatingMode(StateCommandType.Henched);
+        }
+
+        public static void RotationStop() => ChangeOperatingMode(StateCommandType.Off);
+
+        internal static void Dispose() => RotationSolverRebornIPC.DisposeAll(_disposalTokens);
+    }
+
+}


### PR DESCRIPTION
This pull request adds integration with the RotationSolverReborn (RSR) plugin, allowing users to automate combat rotations using RSR if it is available. The changes introduce new configuration options, update the plugin initialization, and add the necessary IPC logic to interact with RSR.

**RSR Integration and IPC Communication:**

* Added a new `RotationSolverRebornIPC` service (`Battlevest/Services/RotationSolverRebornIPC.cs`) that provides IPC wrappers and enums for communicating with the RSR plugin, including commands to start and stop rotation automation.
* Updated the combat logic in `Core.cs` to call RSR's rotation automation methods (`RotationAuto` and `RotationStop`) based on the new configuration and plugin availability.

**Configuration and UI Updates:**

* Added a new configuration option `UseRSR` to the `Config` class, enabling users to toggle RSR integration.
* Updated the main window UI to include a checkbox for enabling RSR, along with a plugin availability indicator for RotationSolver.

**Initialization Changes:**

* Modified the plugin initialization to pass `Module.DalamudReflector` to `ECommonsMain.Init`, supporting the new reflection-based plugin checks required for RSR integration.